### PR TITLE
Cocoapods support

### DIFF
--- a/NeoveraColorPicker.podspec
+++ b/NeoveraColorPicker.podspec
@@ -7,11 +7,11 @@ Pod::Spec.new do |s|
   s.author = 'Neovera'
   s.source = {
     :git => 'https://github.com/neovera/colorpicker.git',
-    :tag => '1.0'
+    :commit => '7e40a227f40d3e7328deb5e2f9953f85b6dd095c'
   }
   s.platform = :ios, '5.0'
-  s.source_files = 'Source/'
-  s.public_header_files = 'Source/'
+  s.source_files =  'Source/'
+  s.resources    = 'Source/*.{xib}', 'Source/colorPicker.bundle'
   s.frameworks = 'UIKit', 'QuartzCore'
   s.requires_arc = true
 end


### PR DESCRIPTION
I've created a pod spec for cocoapods which will allow usage of the color picker via the cocoapods system. I've also tagged this as 1.0

To have cocoapods manage it, you simply need to add the following to your podfile (provided you merge this in):

pod 'NeoveraColorPicker', :podspec => 'https://raw.github.com/neovera/colorpicker/master/NeoveraColorPicker.podspec'

Alternatively, the podspec can be submitted to the cocopods team which will then allow users to simply use:
pod 'NeoveraColorPicker', '1.0'
