### PR TITLE
View controller presentation should be over current context.

### DIFF
--- a/Source/NEOColorPickerViewController.m
+++ b/Source/NEOColorPickerViewController.m
@@ -176,6 +176,7 @@
     controller.disallowOpacitySelection = self.disallowOpacitySelection;
     controller.selectedColor = self.selectedColor;
     self.savedColor = self.selectedColor;
+    controller.modalPresentationStyle = UIModalPresentationCurrentContext;
     [self.navigationController pushViewController:controller animated:YES];
 }
 
@@ -212,6 +213,7 @@
     controller.selectedColor = self.selectedColor;
     controller.selectedColorText = self.selectedColorText;
     self.savedColor = self.selectedColor;
+    controller.modalPresentationStyle = UIModalPresentationCurrentContext;
     [self.navigationController pushViewController:controller animated:YES];
 }
 
@@ -229,6 +231,7 @@
     controller.title = (self.favoritesTitle.length == 0 ? @"Favorites" : self.favoritesTitle);
     controller.selectedColorText = self.selectedColorText;
     self.savedColor = self.selectedColor;
+    controller.modalPresentationStyle = UIModalPresentationCurrentContext;
     [self.navigationController pushViewController:controller animated:YES];
 }
 


### PR DESCRIPTION
Pressed the pull request trigger to soon...
Colorpicker runs fine and looks great on iOS 8.4 and 9.0.
This is a simple pull request that sets the modal presentation style to "Current Context"
It's important when using the VC on a popover or modal.
